### PR TITLE
#39 fix: recoil-persist 설치, 새로고침 시 recoil 데이터 유지하기

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react-query": "^3.39.3",
     "react-router-dom": "^6.14.1",
     "recoil": "^0.7.7",
+    "recoil-persist": "^5.1.0",
     "sort-by": "^1.2.0",
     "styled-components": "^5.3.9",
     "yarn": "^1.22.19",

--- a/src/hook/useLogin.tsx
+++ b/src/hook/useLogin.tsx
@@ -2,15 +2,15 @@ import React, { useState, useEffect } from 'react'
 import { useMutation, useQuery } from 'react-query'
 import { useNavigate } from 'react-router-dom'
 import { getAuthLogin, getUserInfo } from '../service/apis'
-import { useRecoilState } from 'recoil'
 import { userInfoState } from '../recoil/userInfo'
+import { useSetRecoilState } from 'recoil'
 
 export const useLogin = () => {
   const [email, setEmail] = useState<string>('')
   const [errorMessage, setErrorMessage] = useState<string>('')
   const navigate = useNavigate()
 
-  const [userInfo, setUserInfo] = useRecoilState(userInfoState)
+  const setUserInfo = useSetRecoilState(userInfoState)
 
   // 로그인 API
   const { mutate, isLoading } = useMutation(getAuthLogin)
@@ -25,16 +25,17 @@ export const useLogin = () => {
         nickname: data.nickname,
       })
 
-      navigate('/mypage')
+      setTimeout(() => {
+        navigate('/mypage')
+      })
     },
   })
 
   useEffect(() => {
-    console.log(userInfo)
     if (email) {
       refetch()
     }
-  }, [email, userInfo])
+  }, [email])
 
   const login = (data: any) => {
     mutate(data, {

--- a/src/hook/useLogout.tsx
+++ b/src/hook/useLogout.tsx
@@ -1,14 +1,15 @@
 import React from 'react'
 import { useNavigate } from 'react-router-dom'
+import { useResetRecoilState } from 'recoil'
+import { userInfoState } from '../recoil/userInfo'
 
 export const useLogout = () => {
   const navigate = useNavigate()
+  const resetUserInfo = useResetRecoilState(userInfoState)
 
   const logout = () => {
-    localStorage.removeItem('email')
-    localStorage.removeItem('nickname')
     localStorage.removeItem('access-token')
-    console.log('로그아웃')
+    resetUserInfo()
 
     setTimeout(() => {
       navigate('/')

--- a/src/recoil/userInfo.tsx
+++ b/src/recoil/userInfo.tsx
@@ -1,4 +1,6 @@
 import { atom } from 'recoil'
+import { recoilPersist } from 'recoil-persist'
+const { persistAtom } = recoilPersist()
 
 type userInfoType = {
   email: string
@@ -6,9 +8,10 @@ type userInfoType = {
 }
 
 export const userInfoState = atom<userInfoType>({
-  key: 'userInfoState',
+  key: 'userInfo',
   default: {
     email: '',
     nickname: '',
   },
+  effects_UNSTABLE: [persistAtom],
 })

--- a/src/view/MyPage.tsx
+++ b/src/view/MyPage.tsx
@@ -14,10 +14,6 @@ export default function MyPage() {
 
   const { logout } = useLogout()
 
-  useEffect(() => {
-    console.log(userInfo)
-  }, [userInfo])
-
   return (
     <main className={`bg-white px-6 py-24 sm:py-32 lg:px-8`}>
       <Header />

--- a/yarn.lock
+++ b/yarn.lock
@@ -1612,6 +1612,11 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
+recoil-persist@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/recoil-persist/-/recoil-persist-5.1.0.tgz#c4232fe04f2e4b6afcc815baff56f2521f6dcde1"
+  integrity sha512-sew4k3uBVJjRWKCSFuBw07Y1p1pBOb0UxLJPxn4G2bX/9xNj+r2xlqYy/BRfyofR/ANfqBU04MIvulppU4ZC0w==
+
 recoil@^0.7.7:
   version "0.7.7"
   resolved "https://registry.yarnpkg.com/recoil/-/recoil-0.7.7.tgz#c5f2c843224384c9c09e4a62c060fb4c1454dc8e"


### PR DESCRIPTION
페이지 새로고침 시 recoil로 저장한 데이터가 초기화 되는 것을 막기 위해
recoil-persist 설치하여 해결했습니다.